### PR TITLE
修改pack信息

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "rong",
+  "version": "0.2.7",
+  "description": "基于fis的前端解决方案",
+  "main": "index.js",
+  "bin" : {
+    "rong" : "bin/rong",
+    "fis-rong":"bin/rong"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/littleweb/fis-rong.git"
+  },
+  "keywords": [
+    "rong",
+    "fis",
+    "fis-rong"
+  ],
+  "author": "littleweb",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/littleweb/fis-rong/issues"
+  },
+  "homepage": "https://github.com/littleweb/fis-rong",
+  "dependencies": {
+    "fis": "^1.9.28",
+    "fis-parser-less": "^0.1.3",
+    "fis-parser-utc": "0.0.2",
+    "fis-postpackager-autoload": "0.0.20",
+    "fis-postpackager-simple": "0.0.26",
+    "fis-postprocessor-require-async": "0.0.9",    
+    "fis-spriter-csssprites" : "0.3.0"    
+  }
+}


### PR DESCRIPTION
新增
"fis-parser-utc”:支持underscore 模板
    "fis-postpackager-autoload": 支持脚手架操作
    "fis-postpackager-simple": 支持零散js css 打包
    "fis-postprocessor-require-async": 支持js amd wrapper

去掉 fis-commond-server 依赖
